### PR TITLE
ConnectionPool class ignores pool size parameter on construction

### DIFF
--- a/connection.php
+++ b/connection.php
@@ -196,7 +196,7 @@ class ConnectionPool {
             $servers = self::$default_servers;
         $this->servers = $servers;
 
-        if (is_null($this->pool_size))
+        if (is_null($pool_size))
             $this->pool_size = max(count($this->servers) * 2, 5);
 
         $this->queue = array();


### PR DESCRIPTION
Fixed pool size bug. Constructor was validating class variable, changed to local variable.
