### PR TITLE
Don't clobber thrift_root if already set

### DIFF
--- a/connection.php
+++ b/connection.php
@@ -1,5 +1,5 @@
 <?php
-$GLOBALS['THRIFT_ROOT'] = dirname(__FILE__) . '/thrift/';
+$GLOBALS['THRIFT_ROOT'] = (isset($GLOBALS['THRIFT_ROOT'])) ? $GLOBALS['THRIFT_ROOT'] : dirname(__FILE__) . '/thrift/';
 require_once $GLOBALS['THRIFT_ROOT'].'/packages/cassandra/Cassandra.php';
 require_once $GLOBALS['THRIFT_ROOT'].'/transport/TSocket.php';
 require_once $GLOBALS['THRIFT_ROOT'].'/protocol/TBinaryProtocol.php';


### PR DESCRIPTION
pretty straightforward for those of use that keep thrift in a different path and set it somewhere else before phpcassa
