### PR TITLE
UUID to CassandraUUID

### DIFF
--- a/columnfamily.php
+++ b/columnfamily.php
@@ -15,7 +15,7 @@ class CassandraUtil {
      * @return a UUID object
      */
     static public function import($bytes) {
-        return UUID::import($bytes);
+        return CassandraUUID::import($bytes);
     }
 
     /**
@@ -27,7 +27,7 @@ class CassandraUtil {
      *        since the UNIX epoch.
      */
     static public function uuid1($node=null, $time=null) {
-        $uuid = UUID::mint(1, $node, null, $time);
+        $uuid = CassandraUUID::mint(1, $node, null, $time);
         return $uuid->bytes;
     }
 
@@ -36,7 +36,7 @@ class CassandraUtil {
      * @return string a byte[] representation of a UUID 
      */
     static public function uuid3($node=null, $namespace=null) {
-        $uuid = UUID::mint(3, $node, $namespace);
+        $uuid = CassandraUUID::mint(3, $node, $namespace);
         return $uuid->bytes;
     }
 
@@ -45,7 +45,7 @@ class CassandraUtil {
      * @return string a byte[] representation of a UUID 
      */
     static public function uuid4() {
-        $uuid = UUID::mint(4);
+        $uuid = CassandraUUID::mint(4);
         return $uuid->bytes;
     }
 
@@ -54,7 +54,7 @@ class CassandraUtil {
      * @return string a byte[] representation of a UUID 
      */
     static public function uuid5($node, $namespace=null) {
-        $uuid = UUID::mint(5, $node, $namespace);
+        $uuid = CassandraUUID::mint(5, $node, $namespace);
         return $uuid->bytes;
     }
 

--- a/test/test_autopacking.php
+++ b/test/test_autopacking.php
@@ -177,9 +177,9 @@ class TestAutopacking extends UnitTestCase {
         $this->TIME2 = CassandraUtil::uuid1();
         $this->TIME3 = CassandraUtil::uuid1();
 
-        $this->LEX1 = UUID::import('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')->bytes;
-        $this->LEX2 = UUID::import('bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb')->bytes;
-        $this->LEX3 = UUID::import('cccccccccccccccccccccccccccccccc')->bytes;
+        $this->LEX1 = CassandraUUID::import('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')->bytes;
+        $this->LEX2 = CassandraUUID::import('bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb')->bytes;
+        $this->LEX3 = CassandraUUID::import('cccccccccccccccccccccccccccccccc')->bytes;
 
 
         parent::__construct();

--- a/uuid.php
+++ b/uuid.php
@@ -41,7 +41,7 @@ require_once('columnfamily.php');
  * @package phpcassa
  * @subpackage uuid
  */
-class UUID {
+class CassandraUUID {
  const MD5  = 3;
  const SHA1 = 5;
  const clearVer = 15;  // 00001111  Clears all bits of version byte with AND


### PR DESCRIPTION
We found that UUID as a class name collides with another UUID class already in use. The other library [https://github.com/fredriklindberg/class.uuid.php] has a public API that is not compatible with the phpcassa version.
