### PR TITLE
Fixes for issues #78 and #79

### DIFF
--- a/lib/phpcassa/UUID/UUIDException.php
+++ b/lib/phpcassa/UUID/UUIDException.php
@@ -1,5 +1,5 @@
 <?php
-namespace phpcassa\Util;
+namespace phpcassa\UUID;
 
 /**
  * @package phpcassa\Util


### PR DESCRIPTION
Hi,

I have fixes for these two issues:

Issue #79: Recursing too deep in ColumnFamilyIterator->next() part II
Issue #78: UUIDException using the wrong namespace
#79 can be verified by

1) create CF with 10K rows
2) delete all rows (not truncate)
3) add 1 row
4) now attempt to get_range to get all rows
