### PR TITLE
Don't modify internal state of array when it's passed by value

### DIFF
--- a/lib/phpcassa/Schema/DataType/DoubleType.php
+++ b/lib/phpcassa/Schema/DataType/DoubleType.php
@@ -17,7 +17,7 @@ class DoubleType extends CassandraType implements Serialized
     }
 
     public function unpack($data, $is_name=true) {
-        $value = array_shift(unpack("d", $data));
+        $value = current(unpack("d", $data));
         if ($is_name) {
             return serialize($value);
         } else {


### PR DESCRIPTION
array_shift(); changes the original array and triggers **E_NOTICE** warning. The array's internal pointer is already on the first position so `current();` can be used instead.
