### PR TITLE
Issue #83: Column metadata not recognized with composite keys

### DIFF
--- a/lib/phpcassa/ColumnFamily.php
+++ b/lib/phpcassa/ColumnFamily.php
@@ -244,7 +244,7 @@ class ColumnFamily {
             $this->autopack_values = true;
             $this->cf_data_type = DataType::get_type_for($this->cfdef->default_validation_class);
             foreach($this->cfdef->column_metadata as $coldef) {
-                $this->col_type_dict[$coldef->name] =
+                $this->col_type_dict[$this->col_name_type->unpack($coldef->name)] =
                         DataType::get_type_for($coldef->validation_class);
             }
         } else {
@@ -927,6 +927,8 @@ class ColumnFamily {
 
         if (!is_scalar($col_name) || is_float($col_name))
             $col_name = serialize($col_name);
+
+        $col_name = $this->col_name_type->unpack($col_name);
 
         if (isset($this->col_type_dict[$col_name])) {
             $dtype = $this->col_type_dict[$col_name];


### PR DESCRIPTION
Possible fix for https://github.com/thobbs/phpcassa/issues/83.

All _pack/unpack_ should use the same mechanisms to query `col_type_dict` but i have  not changed anything except what's strictly needed.

Im not sure about `ColumnFamily::get_data_type_for_col();` as it is never used, should it be removed?

`ColumnFamily::pack_value` serializes col name directly based on `is_scalar()` and seems to work fine.

Would like to hear some feedback if this is the correct way fix this issue.
