### PR TITLE
Multiple TTL for batch_insert

### DIFF
--- a/lib/phpcassa/AbstractColumnFamily.php
+++ b/lib/phpcassa/AbstractColumnFamily.php
@@ -636,19 +636,36 @@ abstract class AbstractColumnFamily {
         if ($timestamp === null)
             $timestamp = Clock::get_time();
 
+        $arrayTTL = false;
+        if(is_array($ttl)){
+            $arrayTTL = true;
+            if(count($ttl) !== count($rows))
+                throw new UnexpectedValueException("ttl array size must match rows array size");
+        }
+        
         $cfmap = array();
         if ($this->insert_format == self::DICTIONARY_FORMAT) {
             foreach($rows as $key => $columns) {
                 $packed_key = $this->pack_key($key, $handle_serialize=true);
+                if($arrayTTL){
+                    $ttlRow = $ttl[$packed_key];
+                } else {
+                    $ttlRow = $ttl;
+                }
                 $cfmap[$packed_key][$this->column_family] =
-                    $this->make_mutation($columns, $timestamp, $ttl);
+                    $this->make_mutation($columns, $timestamp, $ttlRow);
             }
         } else if ($this->insert_format == self::ARRAY_FORMAT) {
             foreach($rows as $row) {
                 list($key, $columns) = $row;
                 $packed_key = $this->pack_key($key);
+                if($arrayTTL){
+                    $ttlRow = $ttl[$packed_key];
+                } else {
+                    $ttlRow = $ttl;
+                }
                 $cfmap[$packed_key][$this->column_family] =
-                    $this->make_mutation($columns, $timestamp, $ttl);
+                    $this->make_mutation($columns, $timestamp, $ttlRow);
             }
         } else {
             throw new UnexpectedValueException("Bad insert_format selected");


### PR DESCRIPTION
For a batch I'm using the function batch_insert but it is not yet possible to specify a different TTL for each row.

With this commit batch_insert can use an array for the parameter TTL. The array must looks like array( key1 -> ttl1, key2 -> ttl2)
