### PR TITLE
Adding support for ttl by column in insert

### DIFF
--- a/test/ColumnFamily/ColumnFamilyTest.php
+++ b/test/ColumnFamily/ColumnFamilyTest.php
@@ -75,6 +75,35 @@ class ColumnFamilyTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals($this->cf->get(self::$KEYS[0]), array('col' => 'val'));
     }
 
+    public function test_insert_get_ttl() {
+
+        //Mandatory for ttl in response
+        $this->cf->return_format = ColumnFamily::OBJECT_FORMAT;
+
+        //Data
+        $columns = array('col1' => 'val1',
+                         'col2' => 'val2',
+                         'col3' => 'val3');
+
+        // 1st test: $ttl is an Int
+        $ttl = 7;
+        $this->cf->insert(self::$KEYS[0], $columns,null,$ttl);
+        $row = $this->cf->get(self::$KEYS[0]);
+        foreach($row as $column){
+            $this->assertEquals($column->ttl,7);
+        }
+        
+        //2nd test: $ttl is an array
+        $ttl = array('col1' => 10,
+                    'col3' => 12);
+
+        $this->cf->insert(self::$KEYS[0], $columns,null,$ttl);
+        $row = $this->cf->get(self::$KEYS[0]);
+        $this->assertEquals($row[0]->ttl,10);
+        $this->assertEquals($row[1]->ttl,NULL);
+        $this->assertEquals($row[2]->ttl,12);
+    }
+
     public function test_insert_multiget() {
         $columns1 = array('1' => 'val1', '2' => 'val2');
         $columns2 = array('3' => 'val1', '4' => 'val2');


### PR DESCRIPTION
I've done a little improvement on my previous code:
- Add a new function "get_ttl" that return a ttl from a ttl array or an int (refactoring)
- Add support for ttl in the insert function. You can now  add a ttl by column, just pass an array TTL: ('column_name1' => 'ttl_column1',...)
- You can now use a TTL array smaller than the column (or row) array. Column (or row) that does not have a matching ttl will not use TTL.
