### PR TITLE
CfMutator fixing

### DIFF
--- a/lib/phpcassa/Batch/CfMutator.php
+++ b/lib/phpcassa/Batch/CfMutator.php
@@ -9,10 +9,9 @@ use phpcassa\Batch\Mutator;
  *
  * @package phpcassa\Batch
  */
-class CfMutator extends AbstractMutator {
+class CfMutator extends Mutator {
 
     protected $cf;
-    protected $mutatorInstance;
 
     /**
      * Initialize a mutator for a given column family.
@@ -31,7 +30,7 @@ class CfMutator extends AbstractMutator {
         else
             $wcl = $write_consistency_level;
 
-        $this->mutatorInstance = new Mutator($column_family->pool, $wcl);
+	parent::__construct($this->cf->pool, $write_consistency_level);
     }
 
     /**
@@ -45,7 +44,7 @@ class CfMutator extends AbstractMutator {
      * @param int $ttl a TTL to apply to all columns inserted here
      */
     public function insert($key, $columns, $timestamp=null, $ttl=null) {
-        return $this->mutatorInstance->insert($this->cf, $key, $columns, $timestamp, $ttl);
+        return parent::insert($this->cf, $key, $columns, $timestamp, $ttl);
     }
 
     /**
@@ -59,6 +58,7 @@ class CfMutator extends AbstractMutator {
      *        this function is called, not when send() is called)
      */
     public function remove($key, $columns=null, $super_column=null, $timestamp=null) {
-        return $this->mutatorInstance->remove($this->cf, $key, $columns, $super_column, $timestamp);
+        return parent::remove($this->cf, $key, $columns, $super_column, $timestamp);
     }
 }
+


### PR DESCRIPTION
CfMutator restructuring:
- inherit Mutator instead of AbstractMutator
- fixing programming logic so we can use send() from AbstractMutator
