### PR TITLE
Fix of CfMutator class

### DIFF
--- a/lib/phpcassa/Batch/AbstractMutator.php
+++ b/lib/phpcassa/Batch/AbstractMutator.php
@@ -7,54 +7,5 @@ namespace phpcassa\Batch;
  */
 abstract class AbstractMutator
 {
-    protected $pool;
-    protected $buffer = array();
-    protected $cl;
-
-    /**
-     * Send all buffered mutations.
-     *
-     * If an error occurs, the buffer will be preserverd, allowing you to
-     * attempt to call send() again later or take other recovery actions.
-     *
-     * @param cassandra\ConsistencyLevel $consistency_level optional
-     *        override for the mutator's default consistency level
-     */
-    public function send($consistency_level=null) {
-        if ($consistency_level === null)
-            $wcl = $this->cl;
-        else
-            $wcl = $consistency_level;
-
-        $mutations = array();
-        foreach ($this->buffer as $mut_set) {
-            list($key, $cf, $cols) = $mut_set;
-
-            if (isset($mutations[$key])) {
-                $key_muts = $mutations[$key];
-            } else {
-                $key_muts = array();
-            }
-
-            if (isset($key_muts[$cf])) {
-                $cf_muts = $key_muts[$cf];
-            } else {
-                $cf_muts = array();
-            }
-
-            $cf_muts = array_merge($cf_muts, $cols);
-            $key_muts[$cf] = $cf_muts;
-            $mutations[$key] = $key_muts;
-        }
-
-        if (!empty($mutations)) {
-            $this->pool->call('batch_mutate', $mutations, $wcl);
-        }
-        $this->buffer = array();
-    }
-
-    protected function enqueue($key, $cf, $mutations) {
-        $mut = array($key, $cf->column_family, $mutations);
-        $this->buffer[] = $mut;
-    }
+   abstract public function send($consistency_level=null);
 }

--- a/lib/phpcassa/Batch/CfMutator.php
+++ b/lib/phpcassa/Batch/CfMutator.php
@@ -61,4 +61,18 @@ class CfMutator extends AbstractMutator {
     public function remove($key, $columns=null, $super_column=null, $timestamp=null) {
         return $this->mutatorInstance->remove($this->cf, $key, $columns, $super_column, $timestamp);
     }
+    
+    /**
+     * Send all buffered mutations.
+     *
+     * If an error occurs, the buffer will be preserverd, allowing you to
+     * attempt to call send() again later or take other recovery actions.
+     *
+     * @param cassandra\ConsistencyLevel $consistency_level optional
+     *        override for the mutator's default consistency level
+     */
+    public function send($consistency_level=null) {
+        return $this->mutatorInstance->send($consistency_level);
+    }
+
 }

--- a/lib/phpcassa/Batch/Mutator.php
+++ b/lib/phpcassa/Batch/Mutator.php
@@ -16,6 +16,10 @@ use cassandra\SlicePredicate;
  */
 class Mutator extends AbstractMutator
 {
+    protected $pool;
+    protected $buffer = array();
+    protected $cl;
+
     /**
      * Intialize a mutator with a connection pool and consistency level.
      *
@@ -93,5 +97,52 @@ class Mutator extends AbstractMutator
         $this->enqueue($packed_key, $column_family, array($mutation));
 
         return $this;
+    }
+    
+    /**
+     * Send all buffered mutations.
+     *
+     * If an error occurs, the buffer will be preserverd, allowing you to
+     * attempt to call send() again later or take other recovery actions.
+     *
+     * @param cassandra\ConsistencyLevel $consistency_level optional
+     *        override for the mutator's default consistency level
+     */
+    public function send($consistency_level=null) {
+        if ($consistency_level === null)
+            $wcl = $this->cl;
+        else
+            $wcl = $consistency_level;
+
+        $mutations = array();
+        foreach ($this->buffer as $mut_set) {
+            list($key, $cf, $cols) = $mut_set;
+
+            if (isset($mutations[$key])) {
+                $key_muts = $mutations[$key];
+            } else {
+                $key_muts = array();
+            }
+
+            if (isset($key_muts[$cf])) {
+                $cf_muts = $key_muts[$cf];
+            } else {
+                $cf_muts = array();
+            }
+
+            $cf_muts = array_merge($cf_muts, $cols);
+            $key_muts[$cf] = $cf_muts;
+            $mutations[$key] = $key_muts;
+        }
+
+        if (!empty($mutations)) {
+            $this->pool->call('batch_mutate', $mutations, $wcl);
+        }
+        $this->buffer = array();
+    }
+
+    protected function enqueue($key, $cf, $mutations) {
+        $mut = array($key, $cf->column_family, $mutations);
+        $this->buffer[] = $mut;
     }
 }


### PR DESCRIPTION
- move all logic from AbstractMutator into Mutator class
- fixing bug(issue) with send() in CfMutator,
  by calling $mutatorInstance->send(),
  without having issue with PHP strict standards
