### PR TITLE
add suggestion of c extension in composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,10 @@
     "require": {
         "php": ">=5.3.0"
     },
-    "autoload":{
+    "suggest": {
+        "ext-thrift_protocol": "Enabling the thrift protocol extension is crucial for phpcassa's performance"
+    },
+    "autoload": {
         "files": ["lib/autoload.php"]
     }
 }


### PR DESCRIPTION
Really minor change, this is a standard way to notify users of extensions that might be useful / work well with the package after a composer install.
