### PR TITLE
BUGFIX: 'Invalid opcode 153/1/8' on eaccelerator

### DIFF
--- a/lib/autoload.php
+++ b/lib/autoload.php
@@ -1,10 +1,12 @@
 <?php
 
-spl_autoload_register(function($className){
+function thobbs_phpcassa_autoload($className){
     if (strpos($className, 'phpcassa') === 0 || strpos($className, 'Thrift') === 0) {
         require_once __DIR__.'/'.str_replace('\\', '/', $className).'.php';
     }
-});
+}
+
+spl_autoload_register('thobbs_phpcassa_autoload');
 
 // This sets up the THRIFT_AUTOLOAD map
 require_once __DIR__.'/cassandra/Cassandra.php';


### PR DESCRIPTION
Removed anonymous function - not supported by eaccelerator.
See: https://github.com/eaccelerator/eaccelerator/issues/16
