### PR TITLE
add alias for master branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,6 @@
             "homepage": "https://github.com/thobbs/phpcassa"
         }
     ],
-    "version": "1.0.a.6",
     "require": {
         "php": ">=5.3.0"
     },
@@ -20,5 +19,10 @@
     },
     "autoload": {
         "files": ["lib/autoload.php"]
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0.x-dev"
+        }
     }
 }


### PR DESCRIPTION
A bit of explanation on this:
- Version key is not required. I don´t remember why I put there... maybe it was something with an old composer version... but anyway it is not required anymore
- Master branch should be aliased as 1.0.x-dev and whenever you bump to 1.1, to 1.1.x-dev
- When you tag a version, you should add something like
  
  "extra": {
      "branch-alias": {
          "v1.0.a.6": "1.0.6"
      }
  }

If you could retag 1.0.a.6 that would be great, otherwise, please keep this in mind for the next 1.0.7 (I don´t know if you had already any plans for it)

and meanwhile, master branch should  remain aliased as 1.0.x-dev or similar
