### PR TITLE
phpcassa\Schema\DataType\UUIDType::pack() accepts string UUIDs

### DIFF
--- a/lib/phpcassa/Schema/DataType/UUIDType.php
+++ b/lib/phpcassa/Schema/DataType/UUIDType.php
@@ -12,8 +12,15 @@ use phpcassa\UUID;
 class UUIDType extends CassandraType implements Serialized
 {
     public function pack($value, $is_name=true, $slice_end=null, $is_data=false) {
-        if ($is_name && $is_data)
+        if ($is_name && $is_data) {
             $value = unserialize($value);
+        } else {
+            if ( UUID::canImport($value) ) {
+                $value = UUID::import($value);
+            } else {
+                throw new InvalidArgumentException(sprintf("%s cannot be converted to UUID",$value));
+            }
+        }
         return $value->bytes;
     }
 

--- a/lib/phpcassa/UUID.php
+++ b/lib/phpcassa/UUID.php
@@ -115,6 +115,16 @@ class UUID {
     public static function import($uuid) {
         return new self(self::makeBin($uuid, 16));
     }
+    
+    /**
+     * Check if value can be accepted by @link(import)
+     * TODO: Not only strings but also binary
+     * @param $maybeUuidAsScalar
+     * @return bool
+     */
+    static public function canImport( $maybeUuidAsScalar ) {
+        return (bool)preg_match('/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/',$maybeUuidAsScalar);
+    }
 
  /**
   * Create a new UUID based on provided data.

--- a/test/Autopacking/AutopackKeysTest.php
+++ b/test/Autopacking/AutopackKeysTest.php
@@ -251,4 +251,20 @@ class AutopackKeysTest extends AutopackBase {
         $res = iterator_to_array($this->uuid_cf->get_indexed_slices($clause));
         $this->assertEquals(array(serialize($uuid1) => array("subcol" => 0)), $res);
     }
+    
+    public function test_uuid_as_string() {
+        $dataKey = 'a0e13b40-ed53-11e2-91e2-0800200c9a66';
+        $dataColumns = array(
+            'b0885790-ed53-11e2-91e2-0800200c9a66' => 'bdb54c20-ed53-11e2-91e2-0800200c9a66',
+        );
+
+        $this->uuid_cf->truncate();
+        $this->uuid_cf->insert(
+            $dataKey,
+            $dataColumns
+        );
+
+        $back = $this->uuid_cf->get($dataKey);
+        $this->assertEquals($back,$dataColumns);
+    }
 }


### PR DESCRIPTION
Quite incomplete and 'works for me' implementation of string UUID auto-packing, helps remove UUID object creation from client software.

Beware: submitted by web, may have mouso, do run tests (success-case only).
