### PR TITLE
add tests with extension, add 5.5, remove old 5.3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,19 @@
 language: php
 
 php:
-  - 5.3.3
   - 5.3
   - 5.4
+  - 5.5
 
 before_install:
   - test -f "/usr/local/cassandra/etc/cassandra-env.sh" && sudo rm -f /usr/local/cassandra/conf/cassandra-env.sh && sudo ln -s /usr/local/cassandra/etc/cassandra-env.sh /usr/local/cassandra/conf/cassandra-env.sh
   - sudo service cassandra start
-  - sleep 3
+  - sleep 5
+
+env:
+  - THRIFT_EXT=no
+  - THRIFT_EXT=yes
+
+before_script:
+  - if [ "$THRIFT_EXT" == "yes" ]; then sh -c "cd ext/thrift_protocol && phpize && ./configure --enable-thrift_protocol && make && sudo make install"; fi
+  - if [ "$THRIFT_EXT" == "yes" ]; then echo "extension=thrift_protocol.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`; fi


### PR DESCRIPTION
Also increased sleep time since sometimes Cassandra was not up yet when tests fired!

You can check that the extension is actually installed looking at:

https://travis-ci.org/ricardclau/phpcassa/builds/9637479 (you can open php -m output to check that thrift_protocol is actually installed)
https://travis-ci.org/ricardclau/phpcassa/builds/9637697 (this is the actual PR)

Please check that I am not missing any parameters while building the extension
