### PR TITLE
Improve/Clean Clock::get_time() method

### DIFF
--- a/lib/phpcassa/Util/Clock.php
+++ b/lib/phpcassa/Util/Clock.php
@@ -12,12 +12,10 @@ class Clock {
      * Get a timestamp with microsecond precision
      */
     static public function get_time() {
-        // By Zach Buller (zachbuller@gmail.com)
-        $time1 = \microtime();
-        \settype($time1, 'string'); //convert to string to keep trailing zeroes
-        $time2 = explode(" ", $time1);
-        $sub_secs = \preg_replace('/0./', '', $time2[0], 1);
-        $time3 = ($time2[1].$sub_secs)/100;
-        return $time3;
+        // By David Maciel (jdmaciel@gmail.com)
+        list($microsecond, $second) = explode(" ", \microtime());
+        // remove '0.' from the beginning and trailing zeros(2) from the end
+        $microsecond = substr($microsecond, 2, -2);
+        return (int) $second . $microsecond;
     }
 }


### PR DESCRIPTION
The original get_time function is more complex than it needs to be. This version is fastest(~30%) and easy to understand
