### PR TITLE
test phpcassa in hhvm, changed some phpunit settings crashing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,10 @@ php:
   - 5.3
   - 5.4
   - 5.5
+  - hhvm
 
-before_install:
-  - test -f "/usr/local/cassandra/etc/cassandra-env.sh" && sudo rm -f /usr/local/cassandra/conf/cassandra-env.sh && sudo ln -s /usr/local/cassandra/etc/cassandra-env.sh /usr/local/cassandra/conf/cassandra-env.sh
-  - sudo service cassandra start
-  - sleep 10
-  - sudo service cassandra status
+services:
+  - cassandra
 
 env:
   - THRIFT_EXT=no
@@ -18,3 +16,13 @@ env:
 before_script:
   - if [ "$THRIFT_EXT" == "yes" ]; then sh -c "cd ext/thrift_protocol && phpize && ./configure --enable-thrift_protocol && make && sudo make install"; fi
   - if [ "$THRIFT_EXT" == "yes" ]; then echo "extension=thrift_protocol.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`; fi
+  # give some more time for Cassandra to finish startup and actually test it
+  - sleep 10
+  - sudo service cassandra status
+
+matrix:
+  exclude:
+    - php: hhvm
+      env: THRIFT_EXT=yes
+  allow_failures:
+    - php: hhvm

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -12,13 +12,11 @@
     convertWarningsToExceptions="true"
     forceCoversAnnotation="false"
     mapTestClassNameToCoveredClassName="false"
-    printerClass="PHPUnit_TextUI_ResultPrinter"
     processIsolation="false"
     stopOnError="false"
     stopOnFailure="false"
     stopOnIncomplete="false"
     stopOnSkipped="false"
-    testSuiteLoaderClass="PHPUnit_Runner_StandardTestSuiteLoader"
     strict="false"
     verbose="false">
 


### PR DESCRIPTION
hhvm is getting momentum these days, probably worth add testing the library with it

almost everything works perfectly, with the exception of some warning "HipHop Warning: Host lookup failed [-10001]: Unknown error -10001 in /home/travis/build/ricardclau/phpcassa/lib/Thrift/Transport/TSocket.php on line 226"

I had to remove the 2 phpunit.xml options because it was failing on hhvm. This is really weird, since they are the default options and actually the output is exactly the same
