### PR TITLE
Performance boost for Composite types with exactly two types

### DIFF
--- a/lib/phpcassa/Schema/DataType.php
+++ b/lib/phpcassa/Schema/DataType.php
@@ -2,6 +2,7 @@
 namespace phpcassa\Schema;
 
 use phpcassa\Schema\DataType\CompositeType;
+use phpcassa\Schema\DataType\DualCompositeType;
 
 /**
  * Maps type strings to packer and unpacker functions.
@@ -78,7 +79,8 @@ class DataType
 
     public static function get_type_for($typestr) {
         if (strpos($typestr, 'CompositeType') !== false) {
-            return new CompositeType(self::get_inner_types($typestr));
+            $inner_types = self::get_inner_types($typestr);
+            return count($inner_types) == 2 ? new DualCompositeType($inner_types) : new CompositeType($inner_types);
         } else if (strpos($typestr, 'ReversedType') !== false) {
             return self::get_type_for(self::get_inner_type($typestr));
         } else {

--- a/lib/phpcassa/Schema/DataType/DualCompositeType.php
+++ b/lib/phpcassa/Schema/DataType/DualCompositeType.php
@@ -14,10 +14,10 @@ class DualCompositeType extends CompositeType
 {
 
     public function unpack($data, $is_name=true) {
-        $mark = unpack("Cm", $data[1])['m'];
+        $mark = unpack("Cm", $data[1]);
         $components = array(
-            $this->inner_types[0]->unpack(substr($data, 2, $mark)),
-            $this->inner_types[1]->unpack(substr($data, $mark + 5, -1)),
+            $this->inner_types[0]->unpack(substr($data, 2, $mark['m'])),
+            $this->inner_types[1]->unpack(substr($data, $mark['m'] + 5, -1)),
         );
 
         if ($is_name) {

--- a/lib/phpcassa/Schema/DataType/DualCompositeType.php
+++ b/lib/phpcassa/Schema/DataType/DualCompositeType.php
@@ -1,0 +1,30 @@
+<?php
+namespace phpcassa\Schema\DataType;
+
+use phpcassa\Schema\DataType\Serialized;
+use phpcassa\Schema\DataType\CompositeType;
+use phpcassa\ColumnFamily;
+
+/**
+ * Holds 2 types as subcomponents.
+ *
+ * @package phpcassa\Schema\DataType
+ */
+class DualCompositeType extends CompositeType
+{
+
+    public function unpack($data, $is_name=true) {
+        $mark = unpack("Cm", $data[1])['m'];
+        $components = array(
+            $this->inner_types[0]->unpack(substr($data, 2, $mark)),
+            $this->inner_types[1]->unpack(substr($data, $mark + 5, -1)),
+        );
+
+        if ($is_name) {
+            return serialize($components);
+        } else {
+            return $components;
+        }
+    }
+
+}


### PR DESCRIPTION
2 substr() function calls instead of 6 per call to unpack()
